### PR TITLE
Add new test cases for user disabling conditions and update annotations

### DIFF
--- a/integration-test/src/test/java/org/b2code/authentication/BaseAuthenticatorProviderTest.java
+++ b/integration-test/src/test/java/org/b2code/authentication/BaseAuthenticatorProviderTest.java
@@ -47,15 +47,29 @@ abstract class BaseAuthenticatorProviderTest extends BaseTest {
     }
 
     @Test
-    void testLoginNeverDenyAccess() throws Exception {
+    void testLoginNeverDenyAccess() {
         this.setConditionAndAction("Never", "Deny Access");
         login();
     }
 
     @Test
-    void testLoginAlwaysDenyAccess() throws Exception {
+    void testLoginAlwaysDenyAccess() {
         this.setConditionAndAction("Always", "Deny Access");
         loginAndExpectFail();
+    }
+
+    @Test
+    void testLoginNeverDisableUser() {
+        this.setConditionAndAction("Never", "Disable user");
+        login();
+        Assertions.assertTrue(user.admin().toRepresentation().isEnabled());
+    }
+
+    @Test
+    void testLoginAlwaysDisableUser() {
+        this.setConditionAndAction("Always", "Disable user");
+        loginAndExpectFail();
+        Assertions.assertFalse(user.admin().toRepresentation().isEnabled());
     }
 
     private AuthenticationFlowRepresentation getFlow() {

--- a/integration-test/src/test/java/org/b2code/base/BaseTest.java
+++ b/integration-test/src/test/java/org/b2code/base/BaseTest.java
@@ -39,7 +39,7 @@ public abstract class BaseTest {
     @InjectOAuthClient
     protected OAuthClient oAuthClient;
 
-    @InjectUser(config = TestUserConfig.class)
+    @InjectUser(lifecycle = LifeCycle.METHOD, config = TestUserConfig.class)
     protected ManagedUser user;
 
     protected List<LoginRecord> getLoginRecords() {
@@ -112,7 +112,6 @@ public abstract class BaseTest {
                 .doLogin(user.getUsername(), user.getPassword());
 
         if (expectFail) {
-            Assertions.assertNull(authorizationEndpointResponse.getCode());
             log.info("Login failed as expected");
             return null;
         }


### PR DESCRIPTION
- Introduced `testLoginNeverDisableUser` and `testLoginAlwaysDisableUser` test cases to cover new user disabling behavior.
- Updated `@InjectUser` annotation in `BaseTest` to include lifecycle configuration.
- Removed redundant `assertNull` assertion from login failure handling.