### PR TITLE
Add a conditional geo information authenticator

### DIFF
--- a/provider/src/main/java/org/b2code/authentication/ip/LocationConditionalAuthenticatorFactory.java
+++ b/provider/src/main/java/org/b2code/authentication/ip/LocationConditionalAuthenticatorFactory.java
@@ -1,0 +1,126 @@
+package org.b2code.authentication.ip;
+
+import com.google.auto.service.AutoService;
+import org.b2code.PluginConstants;
+import org.b2code.authentication.base.AbstractGeoAwareConditionalAuthenticatorFactory;
+import org.b2code.authentication.base.condition.AuthenticatorCondition;
+import org.b2code.authentication.device.DeviceAuthenticatorConfigProperties;
+import org.b2code.authentication.ip.condition.LocationCondition;
+import org.keycloak.Config;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticator;
+import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
+import java.util.List;
+
+/**
+ * Factory for {@link LocationCondition}, registered as a Keycloak conditional authenticator.
+ * Provides configuration properties for location type (country, country ISO code, continent),
+ * match values, and an option to invert the decision.
+ */
+@AutoService(AuthenticatorFactory.class)
+public class LocationConditionalAuthenticatorFactory implements ConditionalAuthenticatorFactory {
+
+    public static final String PROVIDER_ID = PluginConstants.PLUGIN_NAME_LOWER_CASE + "-condition-location";
+
+
+    public static final String COUNTRY="Country name";
+    public static final String COUNTRY_ISO_CODE="Country Iso Code";
+    public static final String CONTINENT="Continent name";
+
+    public static final String CONFIG_VALUE_TYPE="value-type";
+    public static final String CONFIG_VALUES="values";
+    public static final String CONFIG_REVERT="revert";
+
+    private static final List<String> CONDITION_OPTIONS = List.of(COUNTRY_ISO_CODE, COUNTRY, CONTINENT);
+
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Condition - " + PluginConstants.PLUGIN_NAME + " Location";
+    }
+
+    @Override
+    public String getHelpText() {
+        return LocationCondition.instance().getHelpText();
+    }
+
+
+    @Override
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return new AuthenticationExecutionModel.Requirement[0];
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+
+        ProviderConfigProperty values_type = new ProviderConfigProperty();
+        values_type.setName(CONFIG_VALUE_TYPE);
+        values_type.setLabel("Values type");
+        values_type.setType(ProviderConfigProperty.LIST_TYPE);
+        values_type.setRequired(true);
+        values_type.setDefaultValue(COUNTRY_ISO_CODE);
+        values_type.setHelpText("Select the type of value.\n");
+        values_type.setOptions(CONDITION_OPTIONS);
+
+
+        ProviderConfigProperty values = new ProviderConfigProperty();
+        values.setName(CONFIG_VALUES);
+        values.setLabel("Values");
+        values.setType(ProviderConfigProperty.MULTIVALUED_STRING_TYPE);
+        values.setDefaultValue(false);
+        values.setHelpText("List of the match values\n");
+
+        ProviderConfigProperty revert_decision = new ProviderConfigProperty();
+        revert_decision.setName(CONFIG_REVERT);
+        revert_decision.setLabel("Inverse decision");
+        revert_decision.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+        revert_decision.setDefaultValue(false);
+        revert_decision.setHelpText("Revert de condition decision\n");
+
+        return ProviderConfigurationBuilder.create()
+                .property(values_type)
+                .property(values)
+                .property(revert_decision)
+                .build();
+    }
+
+    @Override
+    public ConditionalAuthenticator getSingleton() {
+        return LocationCondition.SINGLETON;
+    }
+}

--- a/provider/src/main/java/org/b2code/authentication/ip/condition/LocationCondition.java
+++ b/provider/src/main/java/org/b2code/authentication/ip/condition/LocationCondition.java
@@ -1,0 +1,96 @@
+package org.b2code.authentication.ip.condition;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.jbosslog.JBossLog;
+import org.b2code.authentication.ip.LocationConditionalAuthenticatorFactory;
+import org.b2code.geoip.persistence.entity.GeoIpInfo;
+import org.b2code.geoip.provider.GeoIpProvider;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticator;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * Conditional authenticator that matches based on the geographic location (country or continent)
+ * of the client's IP address. Used in Keycloak authentication flows to gate access by location.
+ */
+@JBossLog
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LocationCondition implements ConditionalAuthenticator {
+
+    public static final String LABEL = "Location condition";
+
+    public static final LocationCondition SINGLETON = new LocationCondition();
+
+
+    @Override
+    public boolean matchCondition(AuthenticationFlowContext  context) {
+
+        Map<String, String> config = context.getAuthenticatorConfig().getConfig();
+        var session = context.getSession();
+        GeoIpProvider geoipProvider = session.getProvider(GeoIpProvider.class);
+        String ip = session.getContext().getConnection().getRemoteAddr();
+
+        String valueType = config.getOrDefault(LocationConditionalAuthenticatorFactory.CONFIG_VALUE_TYPE, LocationConditionalAuthenticatorFactory.COUNTRY_ISO_CODE);
+        String values = config.get(LocationConditionalAuthenticatorFactory.CONFIG_VALUES);
+        boolean reveseDecision = Boolean.parseBoolean(config.getOrDefault(LocationConditionalAuthenticatorFactory.CONFIG_REVERT,"false"));
+
+        var value = "??";
+        GeoIpInfo geoIpInfo = geoipProvider != null ? geoipProvider.getIpInfo(ip) : null;
+        if (geoIpInfo != null) {
+            value = switch (valueType) {
+                case LocationConditionalAuthenticatorFactory.COUNTRY_ISO_CODE -> geoIpInfo.getCountryIsoCode() != null ? geoIpInfo.getCountryIsoCode() : "??";
+                case LocationConditionalAuthenticatorFactory.COUNTRY -> geoIpInfo.getCountry() != null ? geoIpInfo.getCountry() : "??";
+                case LocationConditionalAuthenticatorFactory.CONTINENT -> geoIpInfo.getContinent() != null ? geoIpInfo.getContinent() : "??";
+                default -> throw new IllegalStateException("Unexpected value: " + valueType);
+            };
+        } else {
+            log.warnf("Checking location condition for IP: %s, can't get ip info", ip);
+        }
+        var isMatch = Arrays.asList(values.split("##")).contains(value);
+        log.debugf("Checking location condition for IP: %s, Value: %s in Values %s => %s", ip, value, values, isMatch);
+
+        if (reveseDecision)
+            return !isMatch;
+        return isMatch;
+    }
+
+    @Override
+    public void action(AuthenticationFlowContext context) {
+        // Not used
+    }
+
+    @Override
+    public boolean requiresUser() {
+        return false;
+    }
+
+    @Override
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+
+    }
+
+    @Override
+    public void close() {
+        // Does nothing
+    }
+
+    public String getLabel() {
+        return LABEL;
+    }
+
+    /** Returns a human-readable description of this condition for the Keycloak admin console. */
+    public String getHelpText() {
+        return "Check the location of the user's IP address against a list of allowed locations.";
+    }
+
+    /** Returns the singleton instance of this conditional authenticator. */
+    public static LocationCondition instance() {
+        return SINGLETON;
+    }
+}


### PR DESCRIPTION
Add a conditional authenticator that matches the condition based on the country (name or code) or the continent (name).
This will make it possible to block authentications from certain geographic areas within the authentication flow or to increase the required security level.

<img width="554" height="774" alt="image" src="https://github.com/user-attachments/assets/1065bb55-2a81-408a-8c8a-d54a22fd516b" />
